### PR TITLE
docs: add Related Resources section (Helldivers 2 Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 A simple mod manager for the game Helldivers 2.
 
 Read more about it on the [website](https://teutinsa.github.io/hd2mm-site/index.html).
+
+## Related Resources
+
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.


### PR DESCRIPTION
Thanks for building Helldivers2ModManager — a mod manager is a natural companion to a player-facing guide hub.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_end`.)_